### PR TITLE
add member status, fix scrollbar and total online dot

### DIFF
--- a/src/styles/discord.custom-colors.sass
+++ b/src/styles/discord.custom-colors.sass
@@ -102,6 +102,13 @@ html:root,
   --button-outline-primary-text-active: var(--synqats-gb-fg-1)
   --button-outline-primary-text-hover: var(--synqats-gb-fg-1)
 
+  --scrollbar-thin-thumb: var(--synqats-gb-bg-1)
+  --scrollbar-thin-track: var(--synqats-gb-bg-0)
+  --scrollbar-auto-thumb: var(--synqats-gb-bg-0)
+  --scrollbar-auto-track: var(--synqats-gb-bg-1)
+  --scrollbar-auto-scrollbar-color-thumb: var(--synqats-gb-bg-1)
+  --scrollbar-auto-scrollbar-color-track: var(--synqats-gb-bg-1)
+
   --brand-experiment: var(--synqats-gb-accent-purple)
   --brand-100: var(--synqats-gb-accent-purple)
   --brand-130: var(--synqats-gb-accent-purple)

--- a/src/styles/discord.custom-styling.sass
+++ b/src/styles/discord.custom-styling.sass
@@ -36,8 +36,7 @@ section[class*='panels']
 
 
 div[class*='members']
-  [class*='member']
-    margin-left: unset
+  [class*=member]:not([class*='vc-membercount-online-dot'])
     background: unset
 
 div[class*='gradientContainer'][class*='gradientBottom']
@@ -66,7 +65,7 @@ main[class*='chatContent']
 
 [class*='member']
   [class*='subText']
-    display: none
+    display: flex
 
 [class*='membersGroup']
   height: unset


### PR DESCRIPTION
add member status, fix scrollbar and online dot, bump version

- resolves #13 
- fixes online / total member count padding & dot
- adds member status to sidebar -- not sure if it was left out on purpose...

# before:
![{A155B5B2-DEA4-4356-A904-A65786ACD568}](https://github.com/user-attachments/assets/eac57632-dce4-4733-abdf-789e1360a95b)

![{F2434AAD-8929-4E0C-8861-EA42A52FFB0E}](https://github.com/user-attachments/assets/9d236fa3-d2c7-4e67-9696-aa274d43efd4)

![{A0543326-0D87-481C-B669-392DF51223EF}](https://github.com/user-attachments/assets/9e0eb3e2-ccbf-4393-8ee8-32ee4c7c1420)



# after:
![{9D7FF956-BDC2-4315-BC85-F5249C56CBAA}](https://github.com/user-attachments/assets/29ad67f7-5f97-47b6-9d51-b3edaaed3905)

![{BFC118FC-3572-474A-85B7-452DFF82AE46}](https://github.com/user-attachments/assets/37e58ff0-2b46-44dc-97c9-75f81ceae3bc)

![{533D7016-D95E-4228-AC92-1E88C0FDB486}](https://github.com/user-attachments/assets/baed784d-bae7-44da-b1f2-6fb7f5e9541d)



